### PR TITLE
Cache merged surface rules based on input

### DIFF
--- a/src/main/java/com/github/alexthe666/citadel/mixin/NoiseBasedChunkGeneratorMixin.java
+++ b/src/main/java/com/github/alexthe666/citadel/mixin/NoiseBasedChunkGeneratorMixin.java
@@ -2,6 +2,7 @@ package com.github.alexthe666.citadel.mixin;
 
 import com.github.alexthe666.citadel.CitadelConstants;
 import com.github.alexthe666.citadel.server.generation.SurfaceRulesManager;
+import net.minecraft.Util;
 import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.SurfaceRules;
@@ -9,11 +10,12 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import java.util.function.Function;
+
 @Mixin(NoiseBasedChunkGenerator.class)
 public class NoiseBasedChunkGeneratorMixin {
 
-    private boolean mergedSurfaceRules = false;
-    private SurfaceRules.RuleSource mergedSurfaceRule = null;
+    private final Function<SurfaceRules.RuleSource, SurfaceRules.RuleSource> mergedSurfaceRule = Util.memoize(SurfaceRulesManager::mergeOverworldRules);
 
     @Redirect(
             method = {"Lnet/minecraft/world/level/levelgen/NoiseBasedChunkGenerator;buildSurface(Lnet/minecraft/world/level/chunk/ChunkAccess;Lnet/minecraft/world/level/levelgen/WorldGenerationContext;Lnet/minecraft/world/level/levelgen/RandomState;Lnet/minecraft/world/level/StructureManager;Lnet/minecraft/world/level/biome/BiomeManager;Lnet/minecraft/core/Registry;Lnet/minecraft/world/level/levelgen/blending/Blender;)V"},
@@ -21,7 +23,7 @@ public class NoiseBasedChunkGeneratorMixin {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings;surfaceRule()Lnet/minecraft/world/level/levelgen/SurfaceRules$RuleSource;")
     )
     private SurfaceRules.RuleSource citadel_buildSurface_surfaceRuleRedirect(NoiseGeneratorSettings noiseGeneratorSettings) {
-        return getMergedSurfaceRule(noiseGeneratorSettings.surfaceRule());
+        return this.mergedSurfaceRule.apply(noiseGeneratorSettings.surfaceRule());
     }
 
     @Redirect(
@@ -30,14 +32,6 @@ public class NoiseBasedChunkGeneratorMixin {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings;surfaceRule()Lnet/minecraft/world/level/levelgen/SurfaceRules$RuleSource;")
     )
     private SurfaceRules.RuleSource citadel_applyCarvers_surfaceRuleRedirect(NoiseGeneratorSettings noiseGeneratorSettings) {
-        return getMergedSurfaceRule(noiseGeneratorSettings.surfaceRule());
-    }
-
-    private SurfaceRules.RuleSource getMergedSurfaceRule(SurfaceRules.RuleSource rules) {
-        if (!mergedSurfaceRules) {
-            mergedSurfaceRules = true;
-            mergedSurfaceRule = SurfaceRulesManager.mergeOverworldRules(rules);
-        }
-        return mergedSurfaceRule == null ? rules : mergedSurfaceRule;
+        return this.mergedSurfaceRule.apply(noiseGeneratorSettings.surfaceRule());
     }
 }


### PR DESCRIPTION
### The issue

Currently, surface rules are merged once per `NoiseBasedChunkGenerator` instance, ignoring any change in the original value. However, this becomes an issue when another mod modifies `NoiseGeneratorSettings.surfaceRules` after `mergedSurfaceRule` has been calculated, as its changes never take effect.

For reproduction steps, see
- Sinytra/Connector#149

### The solution

Rather than keeping the first calculated `mergedSurfaceRule` forever, we re-run this calculation every time the input rules change. This ensures the merged rules will always be up to date and compatible with other mods that might modify them.

Fixes  Sinytra/Connector#149