### PR TITLE
Fix books not dimming the world behind them

### DIFF
--- a/src/main/java/com/github/alexthe666/citadel/client/gui/GuiBasicBook.java
+++ b/src/main/java/com/github/alexthe666/citadel/client/gui/GuiBasicBook.java
@@ -272,15 +272,6 @@ public abstract class GuiBasicBook extends Screen {
         // Do nothing - this prevents the blur effect from being applied
     }
 
-    /**
-     * Override to disable the menu background that was added in Minecraft 1.21
-     * Without this override, the book appears darker due to the overlay
-     */
-    @Override
-    protected void renderMenuBackground(GuiGraphics guiGraphics) {
-        // Do nothing - this prevents the dark menu background from being rendered
-    }
-
     @Override
     public void render(GuiGraphics guiGraphics, int x, int y, float partialTicks) {
         this.mouseX = x;

--- a/src/main/java/com/github/alexthe666/citadel/client/gui/GuiBasicBook.java
+++ b/src/main/java/com/github/alexthe666/citadel/client/gui/GuiBasicBook.java
@@ -273,6 +273,10 @@ public abstract class GuiBasicBook extends Screen {
     }
 
     @Override
+    public void renderBackground(GuiGraphics guiGraphics, int x, int y, float partialTicks) {
+    }
+
+    @Override
     public void render(GuiGraphics guiGraphics, int x, int y, float partialTicks) {
         this.mouseX = x;
         this.mouseY = y;
@@ -280,7 +284,8 @@ public abstract class GuiBasicBook extends Screen {
         int bindingR = bindingColor >> 16 & 255;
         int bindingG = bindingColor >> 8 & 255;
         int bindingB = bindingColor & 255;
-        this.renderBackground(guiGraphics, x, y, partialTicks);
+        this.renderTransparentBackground(guiGraphics);
+        guiGraphics.flush();
         int k = (this.width - this.xSize) / 2;
         int l = (this.height - this.ySize + 128) / 2;
         BookBlit.blitWithColor(guiGraphics, getBookBindingTexture(), k, l, 0, 0, xSize, ySize, xSize, ySize, bindingR, bindingG, bindingB, 255);


### PR DESCRIPTION
Opening a book on 1.21 doesn't dim the world behind it the way it does on 1.20.

`GuiBasicBook` has an empty `renderMenuBackground` override. It was added in c9fe2ea and hasn't shipped in a release, so it only affects this branch.

Deleting it isn't quite enough though. On 1.21 `Screen.render` calls `renderBackground` itself, which it didn't do on 1.20, so the background got drawn a second time over the finished book. And the old 1.20 gradient is still there as `renderTransparentBackground`, nothing just calls it anymore.

So this makes `renderBackground` a no-op and draws the background once in `render()`, before the book. The `flush()` is needed because `fillGradient` is batched while `BookBlit` draws immediately, same as `drawEntityOnScreen` already does.

`renderBlurredBackground` is unreachable now. The blur stays off anyway, happy to remove it if you'd rather.